### PR TITLE
[7] Do not display 'External' decorator on edges

### DIFF
--- a/org.eclipse.emf.ecoretools.design/description/ecore.odesign
+++ b/org.eclipse.emf.ecoretools.design/description/ecore.odesign
@@ -823,7 +823,7 @@
           </ownedTools>
         </toolSections>
         <decorationDescriptionsSet>
-          <decorationDescriptions xsi:type="description:SemanticBasedDecoration" name="External" position="NORTH_EAST" preconditionExpression="service:viewContainerNotSemanticContainer(diagram,containerView)" imageExpression="/org.eclipse.emf.ecoretools.design/icons/full/ovr16/shortcut.gif" domainClass="ecore.EClassifier"/>
+          <decorationDescriptions xsi:type="description:SemanticBasedDecoration" name="External" position="NORTH_EAST" preconditionExpression="aql:self.viewContainerNotSemanticContainer(diagram,containerView) and (not view.oclIsKindOf(diagram::DEdge) or view.actualMapping.useDomainElement)" imageExpression="/org.eclipse.emf.ecoretools.design/icons/full/ovr16/shortcut.gif" domainClass="ecore.EClassifier"/>
         </decorationDescriptionsSet>
         <customization>
           <vsmElementCustomizations xsi:type="description:VSMElementCustomization" predicateExpression="feature:required">


### PR DESCRIPTION
Change `preconditionExpression` of the _External_ `SemanticBasedDecoration`:
* from: `service:viewContainerNotSemanticContainer(diagram,containerView)`
* to: `aql:self.viewContainerNotSemanticContainer(diagram,containerView) and (not view.oclIsKindOf(diagram::DEdge) or view.actualMapping.useDomainElement)`

so that the decorator is not displayed on reference-based edges. In such a case it will still be displayed on the source node which targets the same semantic element.

With this [sample project](https://github.com/eclipse-ecoretools/ecoretools/files/12641117/test-issue-5.zip):

Before:

![before](https://github.com/eclipse-ecoretools/ecoretools/assets/10608/69984cc5-4a75-4926-af45-445ad404f987)

After:

![after](https://github.com/eclipse-ecoretools/ecoretools/assets/10608/51e2e778-dde8-43c5-b231-a8f24e50b4d8)

